### PR TITLE
Implementing GUI menu for inventory database java program

### DIFF
--- a/mySqlDatabaseRemote/src/mySqlDriver2/InventoryMenuGui.java
+++ b/mySqlDatabaseRemote/src/mySqlDriver2/InventoryMenuGui.java
@@ -1,0 +1,84 @@
+package mySqlDatabaseRemote.src.mySqlDriver2;
+
+import java.awt.*;
+import java.awt.event.*;
+import javax.swing.*;
+
+public class InventoryMenuGui extends JFrame {
+    private String menuSelection;
+
+    public InventoryMenuGui(){
+
+    }
+
+    public void displayGuiMenu() {
+        final InventoryMenuGui frame = this;
+
+        // Reference for container: https://www3.ntu.edu.sg/home/ehchua/programming/java/j4a_gui.html
+        // Reference for dropdown: https://www3.ntu.edu.sg/home/ehchua/programming/java/J4a_GUI_2.html
+
+        Container cp = getContentPane();
+        cp.setLayout(new FlowLayout());
+
+        // Create JComboBox for getting the prompt to run
+        cp.add(new JLabel("Select a prompt:"));
+
+        final String[] prompts = {"Create a new record", "Look up a record", "Update a record", "Delete an existing record"};
+        menuSelection = prompts[0]; // Setting initial selection to first item
+
+        final JComboBox<String> selections = new JComboBox<String>(prompts);
+        selections.setPreferredSize(new Dimension(300, 80));
+        cp.add(selections);
+
+        // Update menu selection when something is selected in drop down
+        selections.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if (e.getStateChange() == ItemEvent.SELECTED) {
+                    menuSelection = (String)selections.getSelectedItem();
+                }
+            }
+        });
+
+        final JButton submitSelection= new JButton("Submit");
+        cp.add(submitSelection);
+
+        // Allocate an anonymous instance of an anonymous inner class that
+        // implements ActionListener as ActionEvent listener
+        submitSelection.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                // stop waiting and let method return
+                synchronized(frame){
+                    frame.notify();
+                }
+
+                // When submit button is clicked, close the menu
+                frame.setVisible(false);
+                frame.dispose(); // Close the menu after selection
+            }
+        });
+
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);  // Exit program if close-window button clicked
+        setTitle("Menu:"); // "super" JFrame sets title
+        setSize(350, 225);         // "super" JFrame sets initial size
+        setVisible(true);          // "super" JFrame shows
+
+        // Wait until a selection is made before returning
+        // reference https://stackoverflow.com/questions/20069374/java-swing-main-class-wait-until-jframe-is-closed
+        synchronized(frame){
+            try{
+                frame.wait();
+            }
+            catch(InterruptedException ex)
+            {
+
+            }
+        }
+    }
+
+    public String getMenuSelection(){
+        return menuSelection;
+    }
+
+}

--- a/mySqlDatabaseRemote/src/mySqlDriver2/inventory_db_remote.java
+++ b/mySqlDatabaseRemote/src/mySqlDriver2/inventory_db_remote.java
@@ -34,19 +34,19 @@ public class inventory_db_remote {
 
 		String prompt = menuGui.getMenuSelection();
 
-		if(prompt.contains("a")) {
+		if(prompt.equals("Create a new record")) {
 			createRecord();
 		}
 
-		if(prompt.contains("b")) {
+		if(prompt.equals("Look up a record")) {
 			lookUpRecord();
 		}
 
-		if(prompt.contains("c")) {
+		if(prompt.equals("Update a record")) {
 			updateRecord();
 		}
 
-		if(prompt.contains("d")) {
+		if(prompt.equals("Delete an existing record")) {
 			deleteRecord();
 		}
 	}

--- a/mySqlDatabaseRemote/src/mySqlDriver2/inventory_db_remote.java
+++ b/mySqlDatabaseRemote/src/mySqlDriver2/inventory_db_remote.java
@@ -1,4 +1,4 @@
-package mySqlDriver2;
+package mySqlDatabaseRemote.src.mySqlDriver2;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -14,13 +14,41 @@ public class inventory_db_remote {
 	public static String url = "";
 	public static String username = "";
 	public static String password = "";
+	public static boolean useGui = false;
 	
 	public static void main(String[] args) {
-		
-		
-		displayMenu();
-		
-		
+
+		if (useGui){
+			// if use gui boolean is true, use gui version of the menu.
+			displayGuiMenu();
+		}
+		else{
+			// if use gui boolean is false, use console version of the menu.
+			displayMenu();
+		}
+	}
+
+	public static void displayGuiMenu(){
+		InventoryMenuGui menuGui = new InventoryMenuGui();
+		menuGui.displayGuiMenu();
+
+		String prompt = menuGui.getMenuSelection();
+
+		if(prompt.contains("a")) {
+			createRecord();
+		}
+
+		if(prompt.contains("b")) {
+			lookUpRecord();
+		}
+
+		if(prompt.contains("c")) {
+			updateRecord();
+		}
+
+		if(prompt.contains("d")) {
+			deleteRecord();
+		}
 	}
 	
 	public static void displayMenu() {


### PR DESCRIPTION
- Added a new class InventoryMenuGui to display the menu in GUI form. It lets the user select which operation they want to do from a dropdown list and then closes when the submit button is clicked.

![image](https://user-images.githubusercontent.com/48767805/115132685-868eaf80-9fbf-11eb-970d-77af2300a1d1.png)


- In inventory_db_remote, I added a new method called displayGuiMenu which does the same thing as displayMenu but uses a GUI instead of the console. It creates a new instance of InventoryMenuGui and calls its "displayGuiMenu" method to show the GUI. Once the user selects an option in the GUI, displayGuiMenu calls the method "getMenuSelection" to get that selection and then runs the CRUD operation that it belongs to. 
- I also created a boolean named "useGui" to let us control which version of the code we want to run, GUI or Console. By default it is false and runs our original console version. If we switch it to true, it runs the GUI version
- In this pull request only the menu is a GUI, once the user selects an option the rest is console. Once we create GUIs for the CRUD operations, then the whole thing will be be GUI